### PR TITLE
Fix missing requirements.txt in installing via pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@
 
 from setuptools import setup
 from pip.req import parse_requirements
+import os
 
-requirements_txt = './requirements.txt'
+package_root = os.path.abspath(os.path.dirname(__file__))
+requirements_txt = os.path.join(package_root, 'requirements.txt')
 requires = [str(r.req) for r in parse_requirements(requirements_txt, session=False)]
 
 setup(


### PR DESCRIPTION
For now you will get below error when run `pip install linebot`
```
$ pip install linebot
...
        'Could not open requirements file: %s' % str(exc)
    pip.exceptions.InstallationError: Could not open requirements file: [Errno 2] No such file or directory: './requirements.txt'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/9_/ggs_d8vd48z5ht76s3cwc7qr0000gn/T/pip-build-b4sxttpx/linebot
```

just my faults. This PR will fix above error.