### PR TITLE
python 3 support for json.loads(response.content)

### DIFF
--- a/linebot/client.py
+++ b/linebot/client.py
@@ -132,4 +132,5 @@ class LineBotClient():
         url = self.__generate_url('profiles')
         url = '{}?mids={}'.format(url, ','.join(mids))
         response = self.__get(url)
-        return [UserProfile(contact) for contact in json.loads(response.content)['contacts']]
+        response_json = response.json()
+        return [UserProfile(contact) for contact in response_json['contacts']]


### PR DESCRIPTION
In python 3, json.loads only supports string and not binary. The get_user_profile function will break when response.content is passed in. 

I suggest to use response.json(), which automatically returns the json object. 